### PR TITLE
PUL-837: Add reports to GHA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,11 @@ on:
   repository_dispatch:
     types: [run-e2e-tests]
 
+env:
+  ALLURE_RESULTS_DIR: allure-results
+  AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+  AWS_CLOUDFRONT_DISTRIBUTION: ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION }}
+
 permissions:
   contents: read
   checks: write
@@ -97,6 +102,7 @@ jobs:
           path: |
             playwright-report/**/*.*
             test-results/**/*.*
+            allure-results/**/*.*
 
   reports:
     needs: [test]
@@ -109,13 +115,36 @@ jobs:
         with:
           name: test-results
           path: .
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Generate Allure Report
+        if: always()
+        run: |
+          npm install -g allure-commandline
+          allure generate ${{ env.ALLURE_RESULTS_DIR }} --clean -o allure-report
+      - name: Upload report to S3
+        if: always()
+        run: |
+          # Create unique folder name using environment and run ID
+          REPORT_DIR="${{ github.event.client_payload.environment }}/run-${{ github.run_id }}"
+
+          # Upload to S3
+          aws s3 sync allure-report s3://${{ env.AWS_S3_BUCKET }}/$REPORT_DIR
+
+          # Get CloudFront URL
+          REPORT_URL="https://${{ env.AWS_CLOUDFRONT_DISTRIBUTION }}/$REPORT_DIR"
+          echo "REPORT_URL=$REPORT_URL" >> $GITHUB_ENV
       - name: Publish test report
         if: success() || failure()
         uses: mikepenz/action-junit-report@v4
         with:
           report_paths: './playwright-report/results.xml'
 
-  notify-and-update-pr-statu:
+  notify-and-update-pr-status:
     needs: [test, reports]
     runs-on: ubuntu-latest
     if: always()
@@ -133,7 +162,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*E2E Test Results for ${{ github.event.client_payload.environment }}*\n• Repository: *Smokesignals*\n• PR: ${{ github.event.client_payload.pr_title }}\n• Status: ${{ needs.test.result == 'success' && '✅ Passed' || '❌ Failed' }}\n• Run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run Details>"
+                    "text": "*E2E Test Results for ${{ github.event.client_payload.environment }}*\n• Repository: *Smokesignals*\n• PR: ${{ github.event.client_payload.pr_title }}\n• Status: ${{ needs.test.result == 'success' && '✅ Passed' || '❌ Failed' }}\n• Run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run Details>\n• Report: <${{ env.REPORT_URL }}|View Allure Report>"
                   }
                 }
               ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea/
 node_modules/
 /test-results/
+/allure-results/
+/allure-report/
 /playwright-report/
 /playwright/.cache/
 .vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,26 +9,27 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@eslint/js": "9.12.0",
-        "@faker-js/faker": "9.1.0",
-        "@playwright/test": "^1.49",
-        "@trivago/prettier-plugin-sort-imports": "4.3.0",
-        "@types/faker": "5.5.9",
-        "@types/node": "22.5.5",
-        "dotenv": "16.4.5",
-        "dotenv-cli": "7.4.2",
-        "eslint": "9.12.0",
+        "@eslint/js": "^9.12.0",
+        "@faker-js/faker": "^9.1.0",
+        "@playwright/test": "^1.49.1",
+        "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+        "@types/faker": "^5.5.9",
+        "@types/node": "^22.5.5",
+        "allure-playwright": "^3.0.9",
+        "dotenv": "^16.4.5",
+        "dotenv-cli": "^7.4.2",
+        "eslint": "^9.12.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-playwright": "^1.7.0",
         "eslint-plugin-prettier": "^5.2.1",
-        "faker": "5.5.3",
+        "faker": "^5.5.3",
         "form-data": "^4.0.1",
-        "globals": "15.11.0",
-        "husky": "9.1.6",
-        "prettier": "3.3.3",
-        "ts-node": "10.9.2",
-        "typescript": "5.6.2",
-        "typescript-eslint": "8.8.1"
+        "globals": "^15.11.0",
+        "husky": "^9.1.6",
+        "prettier": "^3.3.3",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.6.2",
+        "typescript-eslint": "^8.8.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -685,13 +686,12 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
-      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.49.0"
+        "playwright": "1.49.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1065,6 +1065,35 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/allure-js-commons": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.0.9.tgz",
+      "integrity": "sha512-ll7h66zkBAwKSuMv2ZIqa9vXztz/I1Q+oUzxMgg7EErwd6ooO04E4nquXE+rS9mJErYs9K1qTVo3KgnPUzCsQQ==",
+      "dev": true,
+      "dependencies": {
+        "md5": "^2.3.0"
+      },
+      "peerDependencies": {
+        "allure-playwright": "3.0.9"
+      },
+      "peerDependenciesMeta": {
+        "allure-playwright": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/allure-playwright": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/allure-playwright/-/allure-playwright-3.0.9.tgz",
+      "integrity": "sha512-5NBVJ50b9iYbzhkLJF0iSWefV4/eWSv+OioRv4kpLKXbnhrQk+wUH/wVt7oxWnZPSrQAuxilckWxZW5BIP3sNQ==",
+      "dev": true,
+      "dependencies": {
+        "allure-js-commons": "3.0.9"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.36.0"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1160,6 +1189,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1220,6 +1258,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -1719,7 +1766,6 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1823,6 +1869,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -1985,6 +2037,17 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -2174,13 +2237,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
-      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.0"
+        "playwright-core": "1.49.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2193,11 +2255,10 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
-      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
   "devDependencies": {
     "@eslint/js": "^9.12.0",
     "@faker-js/faker": "^9.1.0",
-    "@playwright/test": "^1.49.0",
+    "@playwright/test": "1.49.1",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/faker": "^5.5.9",
     "@types/node": "^22.5.5",
+    "allure-playwright": "^3.0.9",
     "dotenv": "^16.4.5",
     "dotenv-cli": "^7.4.2",
     "eslint": "^9.12.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,8 @@ export default defineConfig({
     ['html'],
     ['github'],
     ['json', { outputFile: './playwright-report/results.json' }],
-    ['junit', { outputFile: './playwright-report/results.xml' }]
+    ['junit', { outputFile: './playwright-report/results.xml' }],
+    ['allure-playwright']
   ],
   use: {
     baseURL: BASE_URL,


### PR DESCRIPTION
ticket:
https://pulsate.atlassian.net/browse/PUL-837

- Added allure-results and allure-report directories to .gitignore.
- Updated package-lock.json and package.json to include allure-playwright as a dependency and upgraded @playwright/test to version 1.49.1.
- Modified playwright.config.ts to integrate Allure reporting.
- Enhanced GitHub Actions workflow to configure AWS credentials, generate Allure reports, and upload them to S3, improving CI/CD processes.

These changes improve the testing framework by incorporating Allure reporting and ensuring up-to-date dependencies.