### PR TITLE
PUL-1177: Update InApp E2E UI tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@eslint/js": "^9.12.0",
         "@faker-js/faker": "^9.1.0",
-        "@playwright/test": "^1.51.1",
+        "@playwright/test": "^1.52",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/faker": "^5.5.9",
         "@types/node": "^22.5.5",
@@ -687,13 +687,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
-      "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.51.1"
+        "playwright": "1.52.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2249,13 +2249,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
-      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.51.1"
+        "playwright-core": "1.52.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2268,9 +2268,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
-      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/src/ui/pages/campaignBuilder.page.ts
+++ b/src/ui/pages/campaignBuilder.page.ts
@@ -20,17 +20,12 @@ export class CampaignBuilderPage extends BasePage {
   // =========================================================================
   // Content Section Locators
   // =========================================================================
-  personalMessageSection = this.page.getByText('Personal Message', {
-    exact: true
-  });
+
   imageSection = this.page.getByText('Image', { exact: true });
   headlineSection = this.page.getByText('Headline', { exact: true });
   textSection = this.page.getByText('Text', { exact: true });
   callToActionSection = this.page.getByText('Call to action');
 
-  personalMessageToggle = this.page
-    .locator('div:has-text("Personal Message") ~ div .react-switch-bg')
-    .first();
   imageToggle = this.page
     .locator('div:has-text("Image") ~ div .react-switch-bg')
     .first();
@@ -40,15 +35,6 @@ export class CampaignBuilderPage extends BasePage {
   textToggle = this.page
     .locator('div:has-text("Text") ~ div .react-switch-bg')
     .first();
-
-  personalMessageInput = this.page
-    .locator('div[data-testid="collapse"]')
-    .filter({
-      has: this.page.locator(
-        '.textarea__placeholder:has-text("Add a personal message...")'
-      )
-    })
-    .locator('div[data-testid="textarea"]');
 
   headlineInput = this.page.locator('div:nth-child(2) > .collapse > div > div');
 
@@ -156,10 +142,6 @@ export class CampaignBuilderPage extends BasePage {
   // =========================================================================
   // Content Section Methods
   // =========================================================================
-  async enterPersonalMessage(message: string): Promise<void> {
-    await this.personalMessageInput.fill(message);
-  }
-
   async enterHeadline(headline: string): Promise<void> {
     // Reverted to simpler version based on user's previous commits
     await this.headlineInput.first().click(); // Assuming first() is needed if locator isn't unique
@@ -277,17 +259,9 @@ export class CampaignBuilderPage extends BasePage {
   // Setup Helper Methods
   // =========================================================================
   async expandCollapseSection(
-    section:
-      | 'Personal Message'
-      | 'Image'
-      | 'Headline'
-      | 'Text'
-      | 'Call to Action'
+    section: 'Image' | 'Headline' | 'Text' | 'Call to Action'
   ): Promise<void> {
     switch (section) {
-      case 'Personal Message':
-        await this.personalMessageSection.click();
-        break;
       case 'Image':
         await this.imageSection.click();
         break;
@@ -304,13 +278,10 @@ export class CampaignBuilderPage extends BasePage {
   }
 
   async toggleSectionSwitch(
-    section: 'Personal Message' | 'Image' | 'Headline' | 'Text'
+    section: 'Image' | 'Headline' | 'Text'
   ): Promise<void> {
     let sectionToggle: Locator;
     switch (section) {
-      case 'Personal Message':
-        sectionToggle = this.personalMessageToggle;
-        break;
       case 'Image':
         sectionToggle = this.imageToggle;
         break;

--- a/tests/ui/createInAppCampaign.ui.spec.ts
+++ b/tests/ui/createInAppCampaign.ui.spec.ts
@@ -142,14 +142,12 @@ test.describe('In-App Campaign Creation', () => {
     await campaignBuilderPage.enterCampaignName(campaignName);
     await campaignBuilderPage.clickSaveAndContinue();
 
-    await expect(campaignBuilderPage.personalMessageSection).toBeVisible();
     await expect(campaignBuilderPage.imageSection).toBeVisible();
     await expect(campaignBuilderPage.headlineSection).toBeVisible();
     await expect(campaignBuilderPage.textSection).toBeVisible();
     // await expect(campaignsPage.callToActionSection).toBeVisible();
 
-    // Toggle of Personal Message and Image sections
-    await campaignBuilderPage.toggleSectionSwitch('Personal Message');
+    // Toggle of Image section
     await campaignBuilderPage.toggleSectionSwitch('Image');
 
     // Enter Headline and Text


### PR DESCRIPTION
- Upgraded Playwright and its related packages to version 1.52.0 in `package-lock.json` to ensure compatibility with the latest features and improvements.
- Removed the personal message section and its related methods from `CampaignBuilderPage`, streamlining the code and focusing on essential functionalities.
- Updated UI tests in `createInAppCampaign.ui.spec.ts` to reflect the removal of the personal message section, ensuring tests remain accurate and relevant.