### PR TITLE
PUL-1210: Upgrade tests after removing FF

### DIFF
--- a/src/api/models/feature-flag.model.ts
+++ b/src/api/models/feature-flag.model.ts
@@ -29,8 +29,6 @@ export interface Flags {
   ff_segment_delivery: boolean;
   ff_web_sdk: boolean;
   ff_csv_users_upload: boolean;
-  ff_pulsate_beta: boolean;
-  ff_dashboard_beta: boolean;
   sms_delivery: boolean;
   ff_push: boolean;
   ff_send_to_report_service: boolean;
@@ -45,7 +43,6 @@ export interface Flags {
   ff_core_member_id_upload: boolean;
   ff_restrict_badge_for_mobile_push: boolean;
   ff_demo_mode: boolean;
-  ff_old_app_and_device_stats: boolean;
   ff_opportunities_dashboard: boolean;
   ff_opportunities_stats: boolean;
   ff_small_in_app: boolean;

--- a/src/api/test-data/cms/feature-flags/default.payload.ts
+++ b/src/api/test-data/cms/feature-flags/default.payload.ts
@@ -26,8 +26,6 @@ export const featureFlagsDefault = (): FeatureFlagsRequest => ({
         ff_segment_delivery: false,
         ff_web_sdk: true,
         ff_csv_users_upload: true,
-        ff_pulsate_beta: true,
-        ff_dashboard_beta: true,
         sms_delivery: false,
         ff_push: true,
         ff_send_to_report_service: false,
@@ -42,7 +40,6 @@ export const featureFlagsDefault = (): FeatureFlagsRequest => ({
         ff_core_member_id_upload: false,
         ff_restrict_badge_for_mobile_push: false,
         ff_demo_mode: false,
-        ff_old_app_and_device_stats: false,
         ff_opportunities_dashboard: false,
         ff_opportunities_stats: false,
         ff_small_in_app: true

--- a/src/ui/pages/login.page.ts
+++ b/src/ui/pages/login.page.ts
@@ -67,7 +67,7 @@ export class LoginPage extends BasePage {
     ]);
 
     // Navigate to dashboard directly and wait for load
-    await this.page.goto(`${baseUrl}/mobile/apps/${appId}/dashboard_beta`);
+    await this.page.goto(`${baseUrl}/mobile/apps/${appId}/dashboard`);
 
     return new DashboardPage(this.page, appId);
   }

--- a/tests/ui/login.ui.spec.ts
+++ b/tests/ui/login.ui.spec.ts
@@ -127,7 +127,7 @@ test.describe('Login Functionality', () => {
     // Act
     await loginPage.loginWithToken(adminFrontendAccessToken, appId);
 
-    const expectedURL = `${BASE_URL}/mobile/apps/${appId}/dashboard_beta`;
+    const expectedURL = `${BASE_URL}/mobile/apps/${appId}/dashboard`;
     const dashboardURL = await dashboardPage.validateUrl();
 
     // Assert


### PR DESCRIPTION
- Removed `ff_pulsate_beta`, `ff_dashboard_beta`, and `ff_old_app_and_device_stats` from the `Flags` interface in `feature-flag.model.ts` and the default payload in `default.payload.ts` to clean up unused features.
- Updated the login page navigation URL from `/dashboard_beta` to `/dashboard` in `login.page.ts` for consistency with the current application structure.
- Adjusted the expected URL in the login UI test to match the updated navigation path.